### PR TITLE
Enable net.tcp protocol for default web site on IIS

### DIFF
--- a/4.6.2/Dockerfile
+++ b/4.6.2/Dockerfile
@@ -2,7 +2,11 @@ FROM microsoft/aspnet:4.6.2
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# install WCF services required components.
+# Install Windows components required for WCF service hosted on IIS
 RUN Add-WindowsFeature NET-WCF-TCP-Activation45; \
 Add-WindowsFeature NET-WCF-HTTP-Activation45; \
 Add-WindowsFeature Web-WebSockets
+
+# Enable net.tcp protocol for default web site on IIS 
+RUN windows\system32\inetsrv\appcmd.exe set app 'Default Web Site/' /enabledProtocols:"http,net.tcp"
+EXPOSE 808

--- a/4.7.1/Dockerfile
+++ b/4.7.1/Dockerfile
@@ -2,7 +2,11 @@ FROM microsoft/aspnet:4.7.1
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# install WCF services required components.
+# Install Windows components required for WCF service hosted on IIS
 RUN Add-WindowsFeature NET-WCF-TCP-Activation45; \
 Add-WindowsFeature NET-WCF-HTTP-Activation45; \
 Add-WindowsFeature Web-WebSockets
+
+# Enable net.tcp protocol for default web site on IIS 
+RUN windows\system32\inetsrv\appcmd.exe set app 'Default Web Site/' /enabledProtocols:"http,net.tcp"
+EXPOSE 808

--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -2,7 +2,11 @@ FROM microsoft/aspnet:4.7
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# install WCF services required components.
+# Install Windows components required for WCF service hosted on IIS
 RUN Add-WindowsFeature NET-WCF-TCP-Activation45; \
 Add-WindowsFeature NET-WCF-HTTP-Activation45; \
 Add-WindowsFeature Web-WebSockets
+
+# Enable net.tcp protocol for default web site on IIS 
+RUN windows\system32\inetsrv\appcmd.exe set app 'Default Web Site/' /enabledProtocols:"http,net.tcp"
+EXPOSE 808


### PR DESCRIPTION
I've verified images can be built successfully for 4.6.2 & 4.7. Not for 4.7.1 since it does not exist yet.